### PR TITLE
Add NPM shield to Readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,4 @@
+[![NPM](https://img.shields.io/npm/v/@homebound/graphql-typescript-simple-resolvers)](https://www.npmjs.com/package/@homebound/graphql-typescript-simple-resolvers)
 
 This is a [graphql-code-generator](https://graphql-code-generator.com/) plugin that generates types for implementating an Apollo-/`graphql`-style implementation in TypeScript.
 


### PR DESCRIPTION
I was curious to [try these](https://github.com/homebound-team/graphql-typescript-simple-resolvers/tree/add-npm-badge). I didn't think it would work at first since the repo is private, but I guess it does?