### PR TITLE
Fix union types

### DIFF
--- a/integration/graphql-types.ts
+++ b/integration/graphql-types.ts
@@ -39,6 +39,8 @@ export interface AuthorSummaryResolvers {
 
 export interface BookResolvers {
   name: Resolver<Book, {}, string>;
+  unionProp: Resolver<Book, {}, null | undefined | String | Boolean>;
+  reqUnionProp: Resolver<Book, {}, String | Boolean>;
 }
 
 export interface SaveAuthorResultResolvers {
@@ -63,6 +65,8 @@ export interface AuthorSummary {
 
 export interface Book {
   name: string;
+  unionProp: null | undefined | String | Boolean;
+  reqUnionProp: String | Boolean;
 }
 
 export interface SaveAuthorResult {

--- a/integration/schema.graphql
+++ b/integration/schema.graphql
@@ -17,7 +17,11 @@ type AuthorSummary {
 
 type Book {
   name: String!
+  unionProp: UnionProp
+  reqUnionProp: UnionProp!
 }
+
+union UnionProp = String | Boolean
 
 union SearchResult = Author | Book
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "./node_modules/.bin/jest --watch",
     "coverage": "./node_modules/.bin/jest --collectCoverage",
     "format": "prettier --write 'src/**/*.{ts,js,tsx,jsx}'",
-    "graphql-codegen": "graphql-codegen --config integration/graphql-codegen.yml"
+    "graphql-codegen": "rm integration/graphql-types.ts; graphql-codegen --config integration/graphql-codegen.yml"
   },
   "dependencies": {
     "@graphql-codegen/plugin-helpers": "^1.13.2",

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,8 @@ import {
 import { code, imp } from "ts-poet";
 import { Config } from "./index";
 
+const NULLABLE_TYPES = "| null | undefined";
+
 /** Turns a generic `type` into a TS type, note that we detect non-nulls which means types are initially assumed nullable. */
 export function mapType(config: Config, type: GraphQLOutputType | GraphQLInputObjectType): any {
   if (isNonNullType(type)) {
@@ -79,12 +81,12 @@ function nullableOf(type: unknown): unknown {
   // We allow `| undefined` because it's handy for server impls that want to treat
   // `null` in the database as `undefined`, and the graphql.js runtime will turn
   // `undefined` into `null` for us anyway.
-  return [type, "| null | undefined"];
+  return [type, NULLABLE_TYPES];
 }
 
 /** Unmarks `type` as nullable, i.e. types are always nullable until unwrapped by a GraphQLNonNull parent. */
 function stripNullable(type: unknown): unknown {
-  if (type instanceof Array && type.length == 2 && type[1] === "| null | undefined") {
+  if (type instanceof Array && type.length == 2 && type[1] === NULLABLE_TYPES) {
     return type[0];
   } else {
     return type;
@@ -134,7 +136,7 @@ export function isMappedType(type: GraphQLNamedType, config: Config) {
 
 /** A `.join(...)` that doesn't `toString()` elements so that they can stay codes. */
 function joinCodes(elements: unknown[], delimiter: string): unknown[] {
-  const result: unknown[] = [];
+  const result: unknown[] = [delimiter];
   for (let i = 0; i < elements.length; i++) {
     result.push(elements[i]);
     if (i !== elements.length - 1) {


### PR DESCRIPTION
working on some code with a nullable `union` type property which was resulting in code generated looking like `value: null | undefinedString | Boolean`