### PR TITLE
[COAST-755] Enhanced support for interfaces and union types

### DIFF
--- a/integration/graphql-types.ts
+++ b/integration/graphql-types.ts
@@ -14,8 +14,18 @@ export interface Resolvers {
   DateTime: GraphQLScalarType;
 }
 
-export interface AuthorResolvers {
-  name: Resolver<AuthorId, {}, string>;
+export interface HasNameResolvers<T> {
+  name: Resolver<T, {}, string>;
+}
+
+export interface FieldWithArgsResolvers<T> {
+  field1: Resolver<T, FieldWithArgsField1Args, boolean | null | undefined>;
+}
+
+export interface FieldWithArgsField1Args {
+  input?: boolean | null | undefined;
+}
+export interface AuthorResolvers extends HasNameResolvers<AuthorId>, FieldWithArgsResolvers<AuthorId> {
   summary: Resolver<AuthorId, {}, AuthorSummary>;
   popularity: Resolver<AuthorId, {}, Popularity>;
   working: Resolver<AuthorId, {}, Working | null | undefined>;
@@ -27,7 +37,8 @@ export interface AuthorResolvers {
 export interface QueryResolvers {
   authors: Resolver<{}, QueryAuthorsArgs, AuthorId[]>;
   authorSummaries: Resolver<{}, {}, AuthorSummary[]>;
-  search: Resolver<{}, QuerySearchArgs, Array<AuthorId | Book>>;
+  search: Resolver<{}, QuerySearchArgs, SearchResult[]>;
+  testUnionOfUnions: Resolver<{}, {}, UnionOfUnions | null | undefined>;
 }
 
 export interface MutationResolvers {
@@ -39,10 +50,9 @@ export interface AuthorSummaryResolvers {
   amountOfSales: Resolver<AuthorSummary, {}, number | null | undefined>;
 }
 
-export interface BookResolvers {
-  name: Resolver<Book, {}, string>;
-  unionProp: Resolver<Book, {}, null | undefined | String | Boolean>;
-  reqUnionProp: Resolver<Book, {}, String | Boolean>;
+export interface BookResolvers extends HasNameResolvers<Book>, FieldWithArgsResolvers<Book> {
+  unionProp: Resolver<Book, {}, UnionProp | null | undefined>;
+  reqUnionProp: Resolver<Book, {}, UnionProp>;
 }
 
 export interface ContainerResolvers {
@@ -53,8 +63,8 @@ export interface ContainerResolvers {
 }
 
 export interface SubscriptionResolvers {
-  authorSaved: SubscriptionResolver<Subscription, {}, AuthorId>;
-  searchSub: SubscriptionResolver<Subscription, SubscriptionSearchSubArgs, Array<AuthorId | Book>>;
+  authorSaved: Resolver<Subscription, {}, AuthorId>;
+  searchSub: Resolver<Subscription, SubscriptionSearchSubArgs, SearchResult[]>;
 }
 
 export interface SaveAuthorResultResolvers {
@@ -92,8 +102,9 @@ export interface AuthorSummary {
 
 export interface Book {
   name: string;
-  unionProp: null | undefined | String | Boolean;
-  reqUnionProp: String | Boolean;
+  unionProp: UnionProp | null | undefined;
+  reqUnionProp: UnionProp;
+  field1: boolean | null | undefined;
 }
 
 export interface Container {
@@ -105,7 +116,7 @@ export interface Container {
 
 export interface Subscription {
   authorSaved: AuthorId;
-  searchSub: Array<AuthorId | Book>;
+  searchSub: SearchResult[];
 }
 
 export interface SaveAuthorResult {
@@ -114,6 +125,10 @@ export interface SaveAuthorResult {
 
 export interface HasName {
   name: string;
+}
+
+export interface FieldWithArgs {
+  field1: boolean | null | undefined;
 }
 
 export interface AuthorInput {
@@ -126,3 +141,9 @@ export enum Working {
   Yes = "YES",
   No = "NO",
 }
+
+export type UnionProp = String | Boolean;
+
+export type SearchResult = AuthorId | Book;
+
+export type UnionOfUnions = UnionProp | SearchResult;

--- a/integration/graphql-types.ts
+++ b/integration/graphql-types.ts
@@ -63,8 +63,8 @@ export interface ContainerResolvers {
 }
 
 export interface SubscriptionResolvers {
-  authorSaved: Resolver<Subscription, {}, AuthorId>;
-  searchSub: Resolver<Subscription, SubscriptionSearchSubArgs, SearchResult[]>;
+  authorSaved: SubscriptionResolver<Subscription, {}, AuthorId>;
+  searchSub: SubscriptionResolver<Subscription, SubscriptionSearchSubArgs, SearchResult[]>;
 }
 
 export interface SaveAuthorResultResolvers {

--- a/integration/schema.graphql
+++ b/integration/schema.graphql
@@ -1,5 +1,5 @@
 # An entity that will be a mapped typed
-type Author implements HasName {
+type Author implements HasName & FieldWithArgs {
   name: String!
   summary: AuthorSummary!
   popularity: Popularity!
@@ -7,6 +7,7 @@ type Author implements HasName {
   birthday: Date
   birthdayPartyScheduled: DateTime
   populate: Boolean
+  field1(input: Boolean): Boolean
 }
 
 # A DTO that is just some fields
@@ -15,14 +16,20 @@ type AuthorSummary {
   amountOfSales: Float
 }
 
-type Book implements HasName {
+type Book implements HasName & FieldWithArgs {
   name: String!
   unionProp: UnionProp
   reqUnionProp: UnionProp!
+  field1(input: Boolean): Boolean
 }
 
 interface HasName {
   name: String!
+}
+
+# Check that interfaces with args generate a single args type
+interface FieldWithArgs {
+  field1(input: Boolean): Boolean
 }
 
 # Example of type that uses fields with interfaces
@@ -37,6 +44,8 @@ union UnionProp = String | Boolean
 
 union SearchResult = Author | Book
 
+union UnionOfUnions = UnionProp | SearchResult
+
 schema {
   query: Query
   mutation: Mutation
@@ -47,6 +56,7 @@ type Query {
   authors(id: ID): [Author!]!
   authorSummaries: [AuthorSummary!]!
   search(query: String!): [SearchResult!]!
+  testUnionOfUnions: UnionOfUnions
 }
 
 type Mutation {

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,7 +192,11 @@ function generateFieldSignature(
 
       const root = type instanceof GraphQLObjectType ? mapObjectType(config, type) : "T";
       const result = mapType(config, interfaceToImpls, f.type);
-      return code`${f.name}: Resolver<${root}, ${args}, ${result}>;`;
+      if (isSubscriptionType(type)) {
+        return code`${f.name}: SubscriptionResolver<${root}, ${args}, ${result}>;`;
+      } else {
+        return code`${f.name}: Resolver<${root}, ${args}, ${result}>;`;
+      }
     });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,12 @@
 import {
   GraphQLInterfaceType,
+  GraphQLNamedType,
   GraphQLObjectType,
   GraphQLScalarType,
   GraphQLSchema,
   isInterfaceType,
   isNullableType,
+  isUnionType,
 } from "graphql";
 import { pascalCase } from "change-case";
 import { upperCaseFirst } from "upper-case-first";
@@ -23,6 +25,7 @@ import {
   mapType,
   toImp,
   isSubscriptionType,
+  joinCodes,
 } from "./types";
 import PluginOutput = Types.PluginOutput;
 
@@ -37,6 +40,8 @@ export const plugin: PluginFunction<Config> = async (schema, documents, configFr
   // Load in a default config which ensures that `Record` fields are non-null
   const config = { ...defaultConfig, ...configFromFile };
   const chunks: Code[] = [];
+
+  const interfaceTypes = Object.values(schema.getTypeMap()).filter(isInterfaceType);
 
   const typesThatNeedResolvers = Object.values(schema.getTypeMap())
     .filter(isObjectType)
@@ -65,11 +70,13 @@ export const plugin: PluginFunction<Config> = async (schema, documents, configFr
   // Make the top-level Resolvers interface
   generateTopLevelResolversType(chunks, typesThatMayHaveResolvers, typesThatNeedResolvers, scalars);
 
+  // Make generic resolvers for interfaces
+  generateEachInterfaceResolverType(chunks, config, interfaceToImpls, interfaceTypes);
+
   // Make each resolver for any output type, whether its required or optional
   generateEachResolverType(chunks, config, interfaceToImpls, allTypesWithResolvers);
 
   // For the output types with optional resolvers, make DTOs for them. Mapped types don't need DTOs.
-  const interfaceTypes = Object.values(schema.getTypeMap()).filter(isInterfaceType);
   generateDtosForNonMappedTypes(chunks, config, interfaceToImpls, [...typesThatMayHaveResolvers, ...interfaceTypes]);
 
   // Input types
@@ -78,6 +85,9 @@ export const plugin: PluginFunction<Config> = async (schema, documents, configFr
   // Enums
   generateEnums(chunks, config, schema);
 
+  // Union Types
+  generateUnionTypes(chunks, config, schema);
+
   const content = await code`${chunks}`.toStringWithImports();
   return { content } as PluginOutput;
 };
@@ -85,7 +95,7 @@ export const plugin: PluginFunction<Config> = async (schema, documents, configFr
 function generateTopLevelResolversType(
   chunks: Code[],
   typesThatMayHaveResolvers: GraphQLObjectType[],
-  typesThatNeedResolvers: GraphQLObjectType[],
+  typesThatNeedResolvers: GraphQLNamedType[],
   scalars: GraphQLScalarType[],
 ): void {
   const resolvers = code`
@@ -106,6 +116,23 @@ function generateTopLevelResolversType(
   chunks.push(resolvers);
 }
 
+function generateEachInterfaceResolverType(
+  chunks: Code[],
+  config: Config,
+  interfaceToImpls: Map<GraphQLInterfaceType, GraphQLObjectType[]>,
+  allTypesWithResolvers: GraphQLInterfaceType[],
+) {
+  const argDefs: Code[] = [];
+  allTypesWithResolvers.forEach(type => {
+    chunks.push(code`
+      export interface ${type.name}Resolvers<T> {
+        ${generateFieldSignature(type, config, interfaceToImpls, argDefs)}
+      }
+    `);
+  });
+  argDefs.forEach(a => chunks.push(a));
+}
+
 function generateEachResolverType(
   chunks: Code[],
   config: Config,
@@ -115,29 +142,10 @@ function generateEachResolverType(
   const ctx = toImp(config.contextType);
   const argDefs: Code[] = [];
   allTypesWithResolvers.forEach(type => {
+    const root = mapObjectType(config, type);
     chunks.push(code`
-      export interface ${type.name}Resolvers {
-        ${Object.values(type.getFields()).map(f => {
-          const argsName = `${type.name}${upperCaseFirst(f.name)}Args`;
-          const args = f.args.length > 0 ? argsName : "{}";
-          if (f.args.length > 0) {
-            argDefs.push(code`
-              export interface ${argsName} {
-                ${f.args.map(a => {
-                  const maybeOptional = isNullableType(a.type) ? "?" : "";
-                  return code`${a.name}${maybeOptional}: ${mapType(config, interfaceToImpls, a.type)}; `;
-                })}
-              }`);
-          }
-
-          const root = mapObjectType(config, type);
-          const result = mapType(config, interfaceToImpls, f.type);
-          if (isSubscriptionType(type)) {
-            return code`${f.name}: SubscriptionResolver<${root}, ${args}, ${result}>;`;
-          } else {
-            return code`${f.name}: Resolver<${root}, ${args}, ${result}>;`;
-          }
-        })}
+      export interface ${type.name}Resolvers ${extendInterfaces(type, root)} {
+        ${generateFieldSignature(type, config, interfaceToImpls, argDefs)}
       }
     `);
   });
@@ -155,6 +163,45 @@ function generateEachResolverType(
     }
   `);
   argDefs.forEach(a => chunks.push(a));
+}
+
+function generateFieldSignature(
+  type: GraphQLObjectType | GraphQLInterfaceType,
+  config: Config,
+  interfaceToImpls: Map<GraphQLInterfaceType, GraphQLObjectType[]>,
+  argDefs: Code[],
+) {
+  // For GraphQLObjectType, don't include fields which are coming from an implemented interface
+  const excludeFields =
+    type instanceof GraphQLObjectType ? type.getInterfaces().flatMap(i => Object.keys(i.getFields())) : [];
+
+  return Object.values(type.getFields())
+    .filter(f => !excludeFields.includes(f.name))
+    .map(f => {
+      const argsName = `${type.name}${upperCaseFirst(f.name)}Args`;
+      const args = f.args.length > 0 ? argsName : "{}";
+      if (f.args.length > 0) {
+        argDefs.push(code`
+              export interface ${argsName} {
+                ${f.args.map(a => {
+                  const maybeOptional = isNullableType(a.type) ? "?" : "";
+                  return code`${a.name}${maybeOptional}: ${mapType(config, interfaceToImpls, a.type)}; `;
+                })}
+              }`);
+      }
+
+      const root = type instanceof GraphQLObjectType ? mapObjectType(config, type) : "T";
+      const result = mapType(config, interfaceToImpls, f.type);
+      return code`${f.name}: Resolver<${root}, ${args}, ${result}>;`;
+    });
+}
+
+function extendInterfaces(type: GraphQLObjectType, root: any) {
+  const interfaces = type
+    .getInterfaces()
+    .map(i => code`${i.name}Resolvers<${root}>`)
+    .join(", ");
+  return interfaces ? `extends ${interfaces}` : "";
 }
 
 function generateDtosForNonMappedTypes(
@@ -216,7 +263,21 @@ function generateEnums(chunks: Code[], config: Config, schema: GraphQLSchema): v
     });
 }
 
-function needsResolver(config: Config, t: GraphQLObjectType): boolean {
+function generateUnionTypes(chunks: Code[], config: Config, schema: GraphQLSchema): void {
+  Object.values(schema.getTypeMap())
+    .filter(isUnionType)
+    .filter(isNotMetadataType)
+    .forEach(type => {
+      chunks.push(code`
+        export type ${type.name} = ${joinCodes(
+        type.getTypes().map(t => mapObjectType(config, t)),
+        " | ",
+      )}
+      `);
+    });
+}
+
+function needsResolver(config: Config, t: GraphQLObjectType | GraphQLInterfaceType): boolean {
   return isNotMetadataType(t) && (isMappedType(t, config) || isQueryOrMutationType(t));
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,7 @@ function generateEachInterfaceResolverType(
   config: Config,
   interfaceToImpls: Map<GraphQLInterfaceType, GraphQLObjectType[]>,
   allTypesWithResolvers: GraphQLInterfaceType[],
-) {
+): void {
   const argDefs: Code[] = [];
   allTypesWithResolvers.forEach(type => {
     chunks.push(code`
@@ -138,7 +138,7 @@ function generateEachResolverType(
   config: Config,
   interfaceToImpls: Map<GraphQLInterfaceType, GraphQLObjectType[]>,
   allTypesWithResolvers: GraphQLObjectType[],
-) {
+): void {
   const ctx = toImp(config.contextType);
   const argDefs: Code[] = [];
   allTypesWithResolvers.forEach(type => {
@@ -182,12 +182,12 @@ function generateFieldSignature(
       const args = f.args.length > 0 ? argsName : "{}";
       if (f.args.length > 0) {
         argDefs.push(code`
-              export interface ${argsName} {
-                ${f.args.map(a => {
-                  const maybeOptional = isNullableType(a.type) ? "?" : "";
-                  return code`${a.name}${maybeOptional}: ${mapType(config, interfaceToImpls, a.type)}; `;
-                })}
-              }`);
+          export interface ${argsName} {
+            ${f.args.map(a => {
+              const maybeOptional = isNullableType(a.type) ? "?" : "";
+              return code`${a.name}${maybeOptional}: ${mapType(config, interfaceToImpls, a.type)}; `;
+            })}
+          }`);
       }
 
       const root = type instanceof GraphQLObjectType ? mapObjectType(config, type) : "T";
@@ -200,7 +200,7 @@ function generateFieldSignature(
     });
 }
 
-function extendInterfaces(type: GraphQLObjectType, root: any) {
+function extendInterfaces(type: GraphQLObjectType, root: string): string {
   const interfaces = type
     .getInterfaces()
     .map(i => code`${i.name}Resolvers<${root}>`)

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,10 +48,7 @@ export function mapType(
         } else if (type instanceof GraphQLInputObjectType) {
           return type.name;
         } else if (type instanceof GraphQLUnionType) {
-          return joinCodes(
-            type.getTypes().map(t => mapObjectType(config, t)),
-            " | ",
-          );
+          return type.name;
         } else {
           throw new Error(`Unsupported type ${type}`);
         }
@@ -60,7 +57,7 @@ export function mapType(
   }
 }
 
-export function mapObjectType(config: Config, type: GraphQLObjectType): any {
+export function mapObjectType(config: Config, type: GraphQLNamedType): any {
   if (isQueryOrMutationType(type)) {
     return "{}";
   }
@@ -161,7 +158,7 @@ export function isMappedType(type: GraphQLNamedType, config: Config) {
 }
 
 /** A `.join(...)` that doesn't `toString()` elements so that they can stay codes. */
-function joinCodes(elements: unknown[], delimiter: string): unknown[] {
+export function joinCodes(elements: unknown[], delimiter: string): unknown[] {
   const result: unknown[] = [delimiter];
   for (let i = 0; i < elements.length; i++) {
     result.push(elements[i]);


### PR DESCRIPTION
Some enhancements were needed to support union types and interfaces well.

This includes support for:

1. Create a typescript union type which represents the graphql union type (Note, this also adds support for union types of other union types, which was previously broken):
![image](https://user-images.githubusercontent.com/24765506/98550701-6ddcd980-226a-11eb-8732-f827f5563f79.png)

2. Create a resolver `interface` for GraphQL interface types (including any `Args` types needed for the interface):
![image](https://user-images.githubusercontent.com/24765506/98550876-a2e92c00-226a-11eb-9f7c-29ca8bcdf183.png)

3. Update `object` type resolvers to `extend` any interfaces which are implemented, and exclude interface fields:
![image](https://user-images.githubusercontent.com/24765506/98550956-beeccd80-226a-11eb-8af7-202ab8e87371.png)


