### PR TITLE
Adds types unions for each interface which let's you know which types implement it

### DIFF
--- a/integration/graphql-types.ts
+++ b/integration/graphql-types.ts
@@ -25,6 +25,10 @@ export interface FieldWithArgsResolvers<T> {
 export interface FieldWithArgsField1Args {
   input?: boolean | null | undefined;
 }
+export type HasNameTypes = AuthorId | Book;
+
+export type FieldWithArgsTypes = AuthorId | Book;
+
 export interface AuthorResolvers extends HasNameResolvers<AuthorId>, FieldWithArgsResolvers<AuthorId> {
   summary: Resolver<AuthorId, {}, AuthorSummary>;
   popularity: Resolver<AuthorId, {}, Popularity>;


### PR DESCRIPTION
This will add the following output to `graphql-types.ts`
![image](https://user-images.githubusercontent.com/24765506/101822772-dd5b1880-3af7-11eb-8275-be1829696016.png)

Note `AuthorId` is coming from mappedTypes while the `Book` is defined locally.