### PR TITLE
Use primitive types (string) instead of wrappers (String)

### DIFF
--- a/integration/graphql-types.ts
+++ b/integration/graphql-types.ts
@@ -146,8 +146,10 @@ export enum Working {
   No = "NO",
 }
 
-export type UnionProp = String | Boolean;
+export type UnionProp = string | boolean;
 
 export type SearchResult = AuthorId | Book;
 
 export type UnionOfUnions = UnionProp | SearchResult;
+
+export type UnionWithPrimitives = string | boolean | AuthorId;

--- a/integration/graphql-types.ts
+++ b/integration/graphql-types.ts
@@ -25,6 +25,10 @@ export interface FieldWithArgsResolvers<T> {
 export interface FieldWithArgsField1Args {
   input?: boolean | null | undefined;
 }
+export type HasNameTypes = AuthorId | Book;
+
+export type FieldWithArgsTypes = AuthorId | Book;
+
 export interface AuthorResolvers extends HasNameResolvers<AuthorId>, FieldWithArgsResolvers<AuthorId> {
   summary: Resolver<AuthorId, {}, AuthorSummary>;
   popularity: Resolver<AuthorId, {}, Popularity>;

--- a/integration/schema.graphql
+++ b/integration/schema.graphql
@@ -46,6 +46,8 @@ union SearchResult = Author | Book
 
 union UnionOfUnions = UnionProp | SearchResult
 
+union UnionWithPrimitives = String | Boolean | Author
+
 schema {
   query: Query
   mutation: Mutation

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,33 +27,37 @@ export function mapType(
   } else {
     // Mark whatever type we're on as assumed-nullable, which will be stripped
     // if we're wrapped by a GraphQLNonNull type.
-    return nullableOf(
-      (() => {
-        if (type instanceof GraphQLList) {
-          const elementType = mapType(config, interfaceToImpls, type.ofType);
-          // Union types will be an array and need `Array<...>`.
-          if (elementType instanceof Array) {
-            return code`Array<${elementType}>`;
-          } else {
-            return code`${elementType}[]`;
-          }
-        } else if (type instanceof GraphQLObjectType) {
-          return mapObjectType(config, type);
-        } else if (type instanceof GraphQLInterfaceType) {
-          return mapInterfaceType(config, interfaceToImpls, type);
-        } else if (type instanceof GraphQLScalarType) {
-          return mapScalarType(config, type);
-        } else if (type instanceof GraphQLEnumType) {
-          return mapEnumType(config, type);
-        } else if (type instanceof GraphQLInputObjectType) {
-          return type.name;
-        } else if (type instanceof GraphQLUnionType) {
-          return type.name;
-        } else {
-          throw new Error(`Unsupported type ${type}`);
-        }
-      })(),
-    );
+    return nullableOf((() => mapTypeNonNullable(config, interfaceToImpls, type))());
+  }
+}
+
+export function mapTypeNonNullable(
+  config: Config,
+  interfaceToImpls: Map<GraphQLInterfaceType, GraphQLObjectType[]>,
+  type: GraphQLOutputType | GraphQLInputObjectType,
+) {
+  if (type instanceof GraphQLList) {
+    const elementType = mapType(config, interfaceToImpls, type.ofType);
+    // Union types will be an array and need `Array<...>`.
+    if (elementType instanceof Array) {
+      return code`Array<${elementType}>`;
+    } else {
+      return code`${elementType}[]`;
+    }
+  } else if (type instanceof GraphQLObjectType) {
+    return mapObjectType(config, type);
+  } else if (type instanceof GraphQLInterfaceType) {
+    return mapInterfaceType(config, interfaceToImpls, type);
+  } else if (type instanceof GraphQLScalarType) {
+    return mapScalarType(config, type);
+  } else if (type instanceof GraphQLEnumType) {
+    return mapEnumType(config, type);
+  } else if (type instanceof GraphQLInputObjectType) {
+    return type.name;
+  } else if (type instanceof GraphQLUnionType) {
+    return type.name;
+  } else {
+    throw new Error(`Unsupported type ${type}`);
   }
 }
 


### PR DESCRIPTION
It has previously slipped by that we were using the wrapper types (`String`, `Boolean`, etc..) instead of the primitives (`string`, `boolean`, etc...) when making union types:

![image](https://user-images.githubusercontent.com/24765506/105049876-26798300-5a3b-11eb-8ab7-1d61324dbd2f.png)
