### PR TITLE
feat: support ESM via `emitLegacyCommonJSImports` setting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,7 @@ export const plugin: PluginFunction<Config> = async (schema, documents, configFr
   generateUnionTypes(chunks, config, interfaceToImpls, schema);
 
   const content = code`${chunks}`.toString({
-    ...(config.emitLegacyCommonJSImports ? {} : { importExtensions: "js" }),
+    importExtensions: config.emitLegacyCommonJSImports ? false : "js",
   });
   return { content } as PluginOutput;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,7 +198,7 @@ function generateEachResolverType(
   interfaceToImpls: Map<GraphQLInterfaceType, GraphQLObjectType[]>,
   allTypesWithResolvers: GraphQLObjectType[],
 ): void {
-  const ctx = toImp(config.contextType);
+  const ctx = toImp(config.contextType, { isTypeOnlyImport: true });
   const argDefs: Code[] = [];
   allTypesWithResolvers.forEach((type) => {
     const root = mapObjectType(config, type);

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,9 @@ export const plugin: PluginFunction<Config> = async (schema, documents, configFr
   // Union Types
   generateUnionTypes(chunks, config, interfaceToImpls, schema);
 
-  const content = await code`${chunks}`.toString();
+  const content = code`${chunks}`.toString({
+    ...(config.emitLegacyCommonJSImports ? {} : { importExtensions: "js" }),
+  });
   return { content } as PluginOutput;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import {
 } from "./types";
 import "@homebound/activesupport";
 import PluginOutput = Types.PluginOutput;
+import type { RawConfig } from "@graphql-codegen/visitor-plugin-common";
 
 const builtInScalarsImps = ["Int", "Boolean", "String", "ID", "Float"];
 const GraphQLScalarTypeSymbolImp = imp("GraphQLScalarType@graphql");
@@ -361,15 +362,16 @@ function optionalResolver(config: Config, t: GraphQLObjectType): boolean {
 }
 
 /** The config values we read from the graphql-codegen.yml file. */
-export type Config = {
+export interface Config extends RawConfig {
   contextType: string;
   scalars: Record<string, string>;
   mappers: Record<string, string>;
   enumValues: Record<string, string>;
-};
+}
 
 const defaultConfig: Omit<Config, "contextType"> = {
   scalars: {},
   mappers: {},
   enumValues: {},
+  emitLegacyCommonJSImports: true, // Current upstream default
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ import type { RawConfig } from "@graphql-codegen/visitor-plugin-common";
 
 const builtInScalarsImps = ["Int", "Boolean", "String", "ID", "Float"];
 const GraphQLScalarTypeSymbolImp = imp("GraphQLScalarType@graphql");
-const GraphQLResolveInfoImp = imp("GraphQLResolveInfo@graphql");
+const GraphQLResolveInfoImp = imp("t:GraphQLResolveInfo@graphql");
 
 type TypeMap = ReturnType<GraphQLSchema["getTypeMap"]>;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -322,13 +322,14 @@ function generateEnums(chunks: Code[], config: Config, schema: GraphQLSchema): v
       } else {
         const mapper = parseExternalMapper(mappedEnum);
         if (mapper.isExternal) {
+          const extension = config.emitLegacyCommonJSImports ? "" : ".js";
           if (mapper.isDefault) {
             chunks.push(code`
-              export { default as ${type.name} } from "${mapper.source}";
+              export { default as ${type.name} } from "${mapper.source}${extension}";
             `);
           } else {
             chunks.push(code`
-              export { ${mapper.import} } from "${mapper.source}";
+              export { ${mapper.import} } from "${mapper.source}${extension}";
             `);
           }
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,13 +130,16 @@ export function toImp(spec: string | undefined, typeName?: string): unknown {
   }
   const mapper = parseExternalMapper(spec);
   if (mapper.isExternal) {
+    // Add .ts extension to the source path so ts-poet can transform it based on importExtensions setting
+    const sourceWithExt = `${mapper.source}.ts`;
     // For default imports, use ts-poet = syntax with the type name as the import alias
     if (mapper.isDefault && typeName) {
-      return imp(`${typeName}=${mapper.source}`);
+      return imp(`${typeName}=${sourceWithExt}`);
     }
     // For named imports, use the import element (which may include 'as' aliasing)
-    return imp(`${mapper.import}@${mapper.source}`);
+    return imp(`${mapper.import}@${sourceWithExt}`);
   } else {
+    // TODO: do I need this `else` at all?
     // Internal mapper, just return the type as-is
     return mapper.type;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -139,7 +139,6 @@ export function toImp(spec: string | undefined, typeName?: string): unknown {
     // For named imports, use the import element (which may include 'as' aliasing)
     return imp(`${mapper.import}@${sourceWithExt}`);
   } else {
-    // TODO: do I need this `else` at all?
     // Internal mapper, just return the type as-is
     return mapper.type;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ import {
   GraphQLUnionType,
 } from "graphql";
 import { parseMapper, isExternalMapperType } from "@graphql-codegen/visitor-plugin-common";
-import { Code, code, imp } from "ts-poet";
+import { Code, code, imp, type Import } from "ts-poet";
 import { Config } from "./index";
 
 /** Turns a generic `type` into a TS type, note that we detect non-nulls which means types are initially assumed nullable. */
@@ -127,7 +127,7 @@ export function parseExternalMapper(spec: string): {
 export function toImp(
   spec: string | undefined,
   options: { typeName?: string; isTypeOnlyImport?: boolean } = {},
-): unknown {
+): string | Import | undefined {
   if (!spec) {
     return undefined;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,7 +88,7 @@ function mapEnumType(config: Config, type: GraphQLEnumType): any {
   return toImp(config.enumValues[type.name], { typeName: type.name }) || type.name;
 }
 
-function mapScalarType(config: Config, type: GraphQLScalarType): string | Code {
+function mapScalarType(config: Config, type: GraphQLScalarType): string | Import {
   if (type.name === "String" || type.name === "ID") {
     return "string";
   } else if (type.name === "Int" || type.name === "Float") {
@@ -96,7 +96,7 @@ function mapScalarType(config: Config, type: GraphQLScalarType): string | Code {
   } else if (type.name === "Boolean") {
     return "boolean";
   } else {
-    return (toImp(config.scalars[type.name], { typeName: type.name }) as string | Code) || type.name.toString();
+    return toImp(config.scalars[type.name], { typeName: type.name }) || type.name.toString();
   }
 }
 

--- a/tests/arrays.test.ts
+++ b/tests/arrays.test.ts
@@ -41,7 +41,7 @@ describe("Array handling", () => {
 
     expect(code).toMatchInlineSnapshot(`
      "import type { GraphQLResolveInfo } from "graphql";
-     import { Context } from "./context";
+     import type { Context } from "./context";
      import { AuthorEntity, BookEntity } from "./entities";
 
      export interface Resolvers {

--- a/tests/arrays.test.ts
+++ b/tests/arrays.test.ts
@@ -40,7 +40,7 @@ describe("Array handling", () => {
     });
 
     expect(code).toMatchInlineSnapshot(`
-     "import { GraphQLResolveInfo } from "graphql";
+     "import type { GraphQLResolveInfo } from "graphql";
      import { Context } from "./context";
      import { AuthorEntity, BookEntity } from "./entities";
 

--- a/tests/dto-types.test.ts
+++ b/tests/dto-types.test.ts
@@ -34,7 +34,7 @@ describe("DTO types", () => {
 
     expect(code).toMatchInlineSnapshot(`
      "import type { GraphQLResolveInfo } from "graphql";
-     import { Context } from "./context";
+     import type { Context } from "./context";
 
      export interface Resolvers {
        Query: QueryResolvers;

--- a/tests/dto-types.test.ts
+++ b/tests/dto-types.test.ts
@@ -33,7 +33,7 @@ describe("DTO types", () => {
     const code = await runPlugin(schema);
 
     expect(code).toMatchInlineSnapshot(`
-     "import { GraphQLResolveInfo } from "graphql";
+     "import type { GraphQLResolveInfo } from "graphql";
      import { Context } from "./context";
 
      export interface Resolvers {

--- a/tests/enums.test.ts
+++ b/tests/enums.test.ts
@@ -43,7 +43,7 @@ describe("Enum types", () => {
 
     expect(code).toMatchInlineSnapshot(`
      "import type { GraphQLResolveInfo } from "graphql";
-     import { Context } from "./context";
+     import type { Context } from "./context";
      import { StatusValues } from "./enums";
 
      export interface Resolvers {

--- a/tests/enums.test.ts
+++ b/tests/enums.test.ts
@@ -42,7 +42,7 @@ describe("Enum types", () => {
     });
 
     expect(code).toMatchInlineSnapshot(`
-     "import { GraphQLResolveInfo } from "graphql";
+     "import type { GraphQLResolveInfo } from "graphql";
      import { Context } from "./context";
      import { StatusValues } from "./enums";
 

--- a/tests/input-types.test.ts
+++ b/tests/input-types.test.ts
@@ -46,7 +46,7 @@ describe("Input types", () => {
 
     expect(code).toMatchInlineSnapshot(`
      "import type { GraphQLResolveInfo } from "graphql";
-     import { Context } from "./context";
+     import type { Context } from "./context";
 
      export interface Resolvers {
        Mutation: MutationResolvers;

--- a/tests/input-types.test.ts
+++ b/tests/input-types.test.ts
@@ -45,7 +45,7 @@ describe("Input types", () => {
     const code = await runPlugin(schema);
 
     expect(code).toMatchInlineSnapshot(`
-     "import { GraphQLResolveInfo } from "graphql";
+     "import type { GraphQLResolveInfo } from "graphql";
      import { Context } from "./context";
 
      export interface Resolvers {

--- a/tests/interfaces.test.ts
+++ b/tests/interfaces.test.ts
@@ -71,7 +71,7 @@ describe("Interface support", () => {
 
     expect(code).toMatchInlineSnapshot(`
      "import type { GraphQLResolveInfo } from "graphql";
-     import { Context } from "./context";
+     import type { Context } from "./context";
      import { NodeEntity, PublisherEntity, UserEntity } from "./entities";
 
      export interface Resolvers {

--- a/tests/interfaces.test.ts
+++ b/tests/interfaces.test.ts
@@ -70,7 +70,7 @@ describe("Interface support", () => {
     });
 
     expect(code).toMatchInlineSnapshot(`
-     "import { GraphQLResolveInfo } from "graphql";
+     "import type { GraphQLResolveInfo } from "graphql";
      import { Context } from "./context";
      import { NodeEntity, PublisherEntity, UserEntity } from "./entities";
 

--- a/tests/primitive-types.test.ts
+++ b/tests/primitive-types.test.ts
@@ -20,7 +20,7 @@ describe("Primitive type handling", () => {
 
     expect(code).toMatchInlineSnapshot(`
      "import type { GraphQLResolveInfo } from "graphql";
-     import { Context } from "./context";
+     import type { Context } from "./context";
 
      export interface Resolvers {
        Query: QueryResolvers;
@@ -86,7 +86,7 @@ describe("Primitive type handling", () => {
 
     expect(code).toMatchInlineSnapshot(`
      "import type { GraphQLResolveInfo } from "graphql";
-     import { Context } from "./context";
+     import type { Context } from "./context";
 
      export interface Resolvers {
        Query: QueryResolvers;
@@ -154,7 +154,7 @@ describe("Primitive type handling", () => {
 
     expect(code).toMatchInlineSnapshot(`
      "import type { GraphQLResolveInfo } from "graphql";
-     import { Context } from "./context";
+     import type { Context } from "./context";
 
      export interface Resolvers {
        Query: QueryResolvers;

--- a/tests/primitive-types.test.ts
+++ b/tests/primitive-types.test.ts
@@ -19,7 +19,7 @@ describe("Primitive type handling", () => {
     const code = await runPlugin(schema);
 
     expect(code).toMatchInlineSnapshot(`
-     "import { GraphQLResolveInfo } from "graphql";
+     "import type { GraphQLResolveInfo } from "graphql";
      import { Context } from "./context";
 
      export interface Resolvers {
@@ -85,7 +85,7 @@ describe("Primitive type handling", () => {
     const code = await runPlugin(schema);
 
     expect(code).toMatchInlineSnapshot(`
-     "import { GraphQLResolveInfo } from "graphql";
+     "import type { GraphQLResolveInfo } from "graphql";
      import { Context } from "./context";
 
      export interface Resolvers {
@@ -153,7 +153,7 @@ describe("Primitive type handling", () => {
     const code = await runPlugin(schema);
 
     expect(code).toMatchInlineSnapshot(`
-     "import { GraphQLResolveInfo } from "graphql";
+     "import type { GraphQLResolveInfo } from "graphql";
      import { Context } from "./context";
 
      export interface Resolvers {

--- a/tests/resolvers.test.ts
+++ b/tests/resolvers.test.ts
@@ -463,9 +463,9 @@ describe("Query and mutation resolvers", () => {
        subscribe: (root: R | undefined, args: A, ctx: AppContext, info: GraphQLResolveInfo) => AsyncIterator<T>;
      };
 
-     export { StatusEnum } from "./lib/enums";
+     export { StatusEnum } from "./lib/enums.js";
 
-     export { default as Priority } from "./src/constants";
+     export { default as Priority } from "./src/constants.js";
      "
     `);
   });

--- a/tests/resolvers.test.ts
+++ b/tests/resolvers.test.ts
@@ -40,7 +40,7 @@ describe("Query and mutation resolvers", () => {
     });
 
     expect(code).toMatchInlineSnapshot(`
-     "import { GraphQLResolveInfo } from "graphql";
+     "import type { GraphQLResolveInfo } from "graphql";
      import { Context } from "./context";
      import { AuthorEntity, BookEntity } from "./entities";
 
@@ -164,7 +164,7 @@ describe("Query and mutation resolvers", () => {
     });
 
     expect(code).toMatchInlineSnapshot(`
-     "import { GraphQLResolveInfo } from "graphql";
+     "import type { GraphQLResolveInfo } from "graphql";
      import { Context } from "./context";
      import { PostEntity, UserEntity } from "./entities";
 
@@ -304,7 +304,7 @@ describe("Query and mutation resolvers", () => {
      import Priority from "#src/constants";
      import { AppContext } from "#src/context";
      import { ProductEntity, UserEntity } from "#src/entities";
-     import { GraphQLResolveInfo, GraphQLScalarType } from "graphql";
+     import { type GraphQLResolveInfo, GraphQLScalarType } from "graphql";
 
      export interface Resolvers {
        User: UserResolvers;
@@ -411,7 +411,7 @@ describe("Query and mutation resolvers", () => {
     });
 
     expect(code).toMatchInlineSnapshot(`
-     "import { GraphQLResolveInfo, GraphQLScalarType } from "graphql";
+     "import { type GraphQLResolveInfo, GraphQLScalarType } from "graphql";
      import { StatusEnum } from "./lib/enums";
      import DateTime from "./lib/scalars";
      import { MoneyType } from "./lib/types";

--- a/tests/resolvers.test.ts
+++ b/tests/resolvers.test.ts
@@ -412,12 +412,12 @@ describe("Query and mutation resolvers", () => {
 
     expect(code).toMatchInlineSnapshot(`
      "import { type GraphQLResolveInfo, GraphQLScalarType } from "graphql";
-     import { StatusEnum } from "./lib/enums";
-     import DateTime from "./lib/scalars";
-     import { MoneyType } from "./lib/types";
-     import Priority from "./src/constants";
-     import { AppContext } from "./src/context";
-     import { ProductEntity, UserEntity } from "./src/entities/index";
+     import { StatusEnum } from "./lib/enums.js";
+     import DateTime from "./lib/scalars.js";
+     import { MoneyType } from "./lib/types.js";
+     import Priority from "./src/constants.js";
+     import { AppContext } from "./src/context.js";
+     import { ProductEntity, UserEntity } from "./src/entities/index.js";
 
      export interface Resolvers {
        User: UserResolvers;

--- a/tests/resolvers.test.ts
+++ b/tests/resolvers.test.ts
@@ -401,8 +401,8 @@ describe("Query and mutation resolvers", () => {
         Money: "./lib/types#MoneyType",
       },
       mappers: {
-        User: "./src/entities#UserEntity",
-        Product: "./src/entities#ProductEntity",
+        User: "./src/entities/index#UserEntity",
+        Product: "./src/entities/index#ProductEntity",
       },
       enumValues: {
         Status: "./lib/enums#StatusEnum",
@@ -417,7 +417,7 @@ describe("Query and mutation resolvers", () => {
      import { MoneyType } from "./lib/types";
      import Priority from "./src/constants";
      import { AppContext } from "./src/context";
-     import { ProductEntity, UserEntity } from "./src/entities";
+     import { ProductEntity, UserEntity } from "./src/entities/index";
 
      export interface Resolvers {
        User: UserResolvers;

--- a/tests/resolvers.test.ts
+++ b/tests/resolvers.test.ts
@@ -41,7 +41,7 @@ describe("Query and mutation resolvers", () => {
 
     expect(code).toMatchInlineSnapshot(`
      "import type { GraphQLResolveInfo } from "graphql";
-     import { Context } from "./context";
+     import type { Context } from "./context";
      import { AuthorEntity, BookEntity } from "./entities";
 
      export interface Resolvers {
@@ -165,7 +165,7 @@ describe("Query and mutation resolvers", () => {
 
     expect(code).toMatchInlineSnapshot(`
      "import type { GraphQLResolveInfo } from "graphql";
-     import { Context } from "./context";
+     import type { Context } from "./context";
      import { PostEntity, UserEntity } from "./entities";
 
      export interface Resolvers {
@@ -302,7 +302,7 @@ describe("Query and mutation resolvers", () => {
      import DateTime from "#lib/scalars";
      import { MoneyType } from "#lib/types";
      import Priority from "#src/constants";
-     import { AppContext } from "#src/context";
+     import type { AppContext } from "#src/context";
      import { ProductEntity, UserEntity } from "#src/entities";
      import { type GraphQLResolveInfo, GraphQLScalarType } from "graphql";
 
@@ -416,7 +416,7 @@ describe("Query and mutation resolvers", () => {
      import DateTime from "./lib/scalars.js";
      import { MoneyType } from "./lib/types.js";
      import Priority from "./src/constants.js";
-     import { AppContext } from "./src/context.js";
+     import type { AppContext } from "./src/context.js";
      import { ProductEntity, UserEntity } from "./src/entities/index.js";
 
      export interface Resolvers {

--- a/tests/scalars.test.ts
+++ b/tests/scalars.test.ts
@@ -29,7 +29,7 @@ describe("Scalars", () => {
 
     expect(code).toMatchInlineSnapshot(`
      "import { type GraphQLResolveInfo, GraphQLScalarType } from "graphql";
-     import { Context } from "./context";
+     import type { Context } from "./context";
      import { CustomIdType } from "./scalars";
 
      export interface Resolvers {

--- a/tests/scalars.test.ts
+++ b/tests/scalars.test.ts
@@ -28,7 +28,7 @@ describe("Scalars", () => {
     });
 
     expect(code).toMatchInlineSnapshot(`
-     "import { GraphQLResolveInfo, GraphQLScalarType } from "graphql";
+     "import { type GraphQLResolveInfo, GraphQLScalarType } from "graphql";
      import { Context } from "./context";
      import { CustomIdType } from "./scalars";
 

--- a/tests/subscriptions.test.ts
+++ b/tests/subscriptions.test.ts
@@ -23,7 +23,7 @@ describe("GraphQL subscriptions", () => {
 
     expect(code).toMatchInlineSnapshot(`
      "import type { GraphQLResolveInfo } from "graphql";
-     import { Context } from "./context";
+     import type { Context } from "./context";
 
      export interface Resolvers {
        Query: QueryResolvers;

--- a/tests/subscriptions.test.ts
+++ b/tests/subscriptions.test.ts
@@ -22,7 +22,7 @@ describe("GraphQL subscriptions", () => {
     const code = await runPlugin(schema);
 
     expect(code).toMatchInlineSnapshot(`
-     "import { GraphQLResolveInfo } from "graphql";
+     "import type { GraphQLResolveInfo } from "graphql";
      import { Context } from "./context";
 
      export interface Resolvers {

--- a/tests/unions.test.ts
+++ b/tests/unions.test.ts
@@ -32,7 +32,7 @@ describe("Union types", () => {
 
     expect(code).toMatchInlineSnapshot(`
      "import type { GraphQLResolveInfo } from "graphql";
-     import { Context } from "./context";
+     import type { Context } from "./context";
 
      export interface Resolvers {
        Query: QueryResolvers;

--- a/tests/unions.test.ts
+++ b/tests/unions.test.ts
@@ -31,7 +31,7 @@ describe("Union types", () => {
     const code = await runPlugin(schema);
 
     expect(code).toMatchInlineSnapshot(`
-     "import { GraphQLResolveInfo } from "graphql";
+     "import type { GraphQLResolveInfo } from "graphql";
      import { Context } from "./context";
 
      export interface Resolvers {


### PR DESCRIPTION
Today, we cannot output ESM-compatible code from this library. You can see a small, self-contained example in https://github.com/joist-orm/joist-orm/pull/1620 that show these problems.

This PR updates the ts-poet import statement to always use the `.ts` file extension. Then, when rendering, we use the `importExtensions` config to write the proper import statement.

See inline comments for details.